### PR TITLE
Add webpack production config #96

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "webpack --watch",
     "build": "webpack --bail",
+    "build-production": "webpack --bail --config webpack.config-production.js",
     "test": "mocha-webpack --growl",
     "test-testrpc": "concurrently --kill-others -s first \"testrpc -p ${TESTRPC_PORT:-8545}\" 'npm run test'",
     "lint": "jshint app/javascript/*.js"

--- a/webpack.config-production.js
+++ b/webpack.config-production.js
@@ -1,0 +1,15 @@
+var webpack = require('webpack');
+var config = require('./webpack.config.js');
+
+config.plugins = config.plugins.concat([
+  // Minify code
+  new webpack.optimize.UglifyJsPlugin({
+    compressor: {
+      warnings: false
+    }
+  })
+]);
+
+config.web3Loader.constructorParams.Chess = [false]; // Disable debugging
+
+module.exports = config;


### PR DESCRIPTION
#96

Call `npm run build-production` instead of `npm run build` to build everything with production settings and optimizations.
