### PR TITLE
Implement closePlayerGame in contract

### DIFF
--- a/app/javascript/gamesFactory.js
+++ b/app/javascript/gamesFactory.js
@@ -248,14 +248,16 @@ angular.module('dappChess').factory('games', function (navigation, accounts, $ro
   };
 
   // Fetch games of player
+  const gamesOfPlayersEnd = '0x0000000000000000000000000000000000000000000000000000000000000000';
   for (let accountId of accounts.availableAccounts) {
-    let numberGames = Chess.numberGamesOfPlayers(accountId);
-    if (numberGames === 0) {
-      return;
-    }
-    for (let i = 0; i < numberGames; i++) {
-      let gameId = Chess.gamesOfPlayers(accountId, i);
-      games.add(games.convertArrayToGame(gameId, Chess.games(gameId)));
+    for (let currentGameId = Chess.gamesOfPlayersHeads(accountId);
+         currentGameId !== gamesOfPlayersEnd;
+         currentGameId = Chess.gamesOfPlayers(accountId, currentGameId)) {
+      // Check if the game already exists in the games list
+      let game = games.getGame(currentGameId);
+      if (typeof game === 'undefined') {
+        games.add(games.convertArrayToGame(currentGameId, Chess.games(currentGameId)));
+      }
     }
   }
 

--- a/contract/Chess.sol
+++ b/contract/Chess.sol
@@ -19,6 +19,7 @@
         address nextPlayer;
         address playerWhite; // Player that is white in this game
         address winner;
+        bool ended;
 
         int8[128] state;
     }
@@ -98,6 +99,7 @@
     function initGame(string player1Alias, bool playAsWhite) public {
         // Generate game id based on player's addresses and current block number
         bytes32 gameId = sha3(msg.sender, block.number);
+        games[gameId].ended = false;
 
         // Initialize participants
         games[gameId].player1 = msg.sender;
@@ -671,6 +673,7 @@
             // Sender is not a participant of this game
             throw;
         }
+        games[gameId].ended = true;
 
         GameEnded(gameId, games[gameId].winner);
     }

--- a/test/test_contract.js
+++ b/test/test_contract.js
@@ -272,7 +272,7 @@ describe('Chess contract', function() {
       const end = '0x656e640000000000000000000000000000000000000000000000000000000000';
       for (let currentGameId = Chess.head();
            currentGameId !== end;
-           currentGameId = Chess.openGameIds(currentGameId)) {;
+           currentGameId = Chess.openGameIds(currentGameId)) {
         assert.notEqual(gameId, currentGameId);
         assert.notEqual(gameId2, currentGameId);
       }

--- a/test/test_contract.js
+++ b/test/test_contract.js
@@ -130,7 +130,7 @@ describe('Chess contract', function() {
     });
   });
 
-  describe.only('closePlayerGame()', function () {
+  describe('closePlayerGame()', function () {
     let gameId, gameId2;
     it('should initialize a game with 1 player only', function(done) {
       Chess.initGame('Alice', true, {from: player1, gas: 2000000});

--- a/test/test_contract.js
+++ b/test/test_contract.js
@@ -65,6 +65,10 @@ describe('Chess contract', function() {
         done();
       });
     });
+
+    it('should have set game state to not ended', function() {
+      assert.equal(false, Chess.games(testGames[0])[7]);
+    });
   });
 
   describe('joinGame()', function () {
@@ -106,6 +110,11 @@ describe('Chess contract', function() {
         filter.stopWatching(); // Need to remove filter again
         done();
       });
+    });
+
+    it('should have not change game.ended', function() {
+      assert.equal(false, Chess.games(testGames[0])[7]);
+      assert.equal(false, Chess.games(testGames[1])[7]);
     });
   });
 
@@ -232,6 +241,10 @@ describe('Chess contract', function() {
         filter.stopWatching();
         done();
       });
+    });
+
+    it('should have set game state to ended', function() {
+      assert.equal(true, Chess.games(gameId)[7]);
     });
 
     it('should throw an exception when surrendering a game that already ended', function() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail -->

> Let the user "close" a game by removing it from the `gamesOfPlayers[player]` list, but only if the game is not currently running. A game is running if it has two players and no draw/checkmate occurred.

\+ Changed structure of `gamesOfPlayers` to a "stack" (like openGames).
## Related Issue

<!--- This project only accepts pull requests related to open issues -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here: -->
#82 Implement closePlayerGame contract function
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

I provide multiple tests
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist contributor:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
## Checklist reviewer:
- [x] The code has been peer-reviewed by @graup

<!--- source: https://www.talater.com/open-source-templates/# -->
