### PR TITLE
Elo score calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,5 @@ This is loosely based on [ethereum-webpack-example-dapp](https://github.com/uzyn
   ```bash
   npm run test
   ```
+
+1. You can run only one test file if you like: `npm test -- test/test_elo.js`

--- a/contract/Chess.sol
+++ b/contract/Chess.sol
@@ -13,8 +13,8 @@ import "ChessLogic.sol";
 contract Chess is TurnBasedGame {
     using ChessLogic for ChessLogic.State;
     mapping (bytes32 => ChessLogic.State) gameStates;
-
-
+    //using ELO for eloScores;
+    //mapping (address => ELO.Score) eloScores;
 
     event GameInitialized(bytes32 indexed gameId, address indexed player1, string player1Alias, address playerWhite, uint value);
     event GameJoined(bytes32 indexed gameId, address indexed player1, string player1Alias, address indexed player2, string player2Alias, address playerWhite, uint value);

--- a/contract/ELO.sol
+++ b/contract/ELO.sol
@@ -1,0 +1,103 @@
+/**
+ * Simple ELO score rating system based on
+ * https://en.wikipedia.org/wiki/Elo_rating_system#Mathematical_details
+ */
+library ELO {
+    struct Score {
+        uint score;
+        string alias;
+    }
+    struct Scores {
+        mapping(address => Score) scores;
+    }
+
+    /**
+     * Records a game result for a game between two players.
+     * Winner can be 0 to record a draw
+     */
+    function recordResult(Scores storage self,
+                          address player1, address player2, address winner) {
+        // Get current scores
+        uint scoreA = getScore(self, player1);
+        uint scoreB = getScore(self, player2);
+
+        // Calculate result for player A
+        int resultA = 1; // 0 = lose, 1 = draw, 2 = win
+        if (winner == player1) {
+            resultA = 2;
+        }
+        else if (winner == player2) {
+            resultA = 0;
+        }
+
+        // Calculate new score
+        var (changeA, changeB) = getScoreChange(int(scoreA)-int(scoreB), resultA);
+        setScore(self, player1, uint(int(scoreA) + changeA));
+        setScore(self, player2, uint(int(scoreB) + changeB));
+    }
+
+    /**
+     * Table based expectation formula
+     * E = 1 / ( 1 + 10**((difference)/400))
+     * Table calculated based on inverse: difference = (400*log(1/E-1))/(log(10))
+     * scoreChange = K * (result - E)
+     * K = 20
+     * Because curve is mirrored around 0, uses only one table for positive side
+     * Returns (scoreChangeA, scoreChangeB)
+     */
+    function getScoreChange(int difference, int resultA) returns (int, int) {
+        bool reverse = (difference > 0); // note if difference was negative
+        uint diff = abs(difference); // take absolute to lookup in positive table
+        // Score change lookup table
+        int scoreChange = 10;
+        if (diff >= 798) scoreChange = 20;
+        else if (diff >= 511) scoreChange = 19;
+        else if (diff >= 381) scoreChange = 18;
+        else if (diff >= 301) scoreChange = 17;
+        else if (diff >= 240) scoreChange = 16;
+        else if (diff >= 190) scoreChange = 15;
+        else if (diff >= 147) scoreChange = 14;
+        else if (diff >= 107) scoreChange = 13;
+        else if (diff >= 70) scoreChange = 12;
+        else if (diff >= 34) scoreChange = 11;
+        // Depending on result (win/draw/lose), calculate score changes
+        if (resultA == 2) {
+            return ((reverse ? 20-scoreChange : scoreChange ),
+                    (reverse ? -scoreChange : -(20-scoreChange)));
+        }
+        else if (resultA == 1) {
+            return ((reverse ? scoreChange-10 : 10-scoreChange ),
+                   (reverse ? -(scoreChange-10) : -(10-scoreChange)));
+        }
+        else {
+            return ((reverse ? scoreChange-20 : -scoreChange ),
+                    (reverse ? scoreChange : -(scoreChange-20)));
+        }
+    }
+
+    function abs(int value) returns (uint){
+        if (value>=0) return uint(value);
+        else return uint(-1*value);
+    }
+
+    /**
+     * Get current score for player
+     */
+    function getScore(Scores storage self, address player) returns (uint) {
+        if (self.scores[player].score <= 100) {
+            return 100;
+        }
+        return self.scores[player].score;
+    }
+
+    /**
+     * Set score for player
+     */
+    function setScore(Scores storage self, address player, uint score) {
+        if (score <= 100) {
+            self.scores[player].score = 100;
+        } else {
+            self.scores[player].score = score;
+        }
+    }
+}

--- a/contract/ELO.sol
+++ b/contract/ELO.sol
@@ -46,7 +46,7 @@ library ELO {
      * Returns (scoreChangeA, scoreChangeB)
      */
     function getScoreChange(int difference, int resultA) returns (int, int) {
-        bool reverse = (difference > 0); // note if difference was negative
+        bool reverse = (difference > 0); // note if difference was positive
         uint diff = abs(difference); // take absolute to lookup in positive table
         // Score change lookup table
         int scoreChange = 10;
@@ -66,8 +66,8 @@ library ELO {
                     (reverse ? -scoreChange : -(20-scoreChange)));
         }
         else if (resultA == 1) {
-            return ((reverse ? scoreChange-10 : 10-scoreChange ),
-                   (reverse ? -(scoreChange-10) : -(10-scoreChange)));
+            return ((reverse ? 10-scoreChange : scoreChange-10 ),
+                    (reverse ? -(10-scoreChange) : -(scoreChange-10)));
         }
         else {
             return ((reverse ? scoreChange-20 : -scoreChange ),

--- a/contract/ELO.sol
+++ b/contract/ELO.sol
@@ -40,7 +40,7 @@ library ELO {
      * Table based expectation formula
      * E = 1 / ( 1 + 10**((difference)/400))
      * Table calculated based on inverse: difference = (400*log(1/E-1))/(log(10))
-     * scoreChange = K * (result - E)
+     * scoreChange = Round( K * (result - E) )
      * K = 20
      * Because curve is mirrored around 0, uses only one table for positive side
      * Returns (scoreChangeA, scoreChangeB)
@@ -50,16 +50,16 @@ library ELO {
         uint diff = abs(difference); // take absolute to lookup in positive table
         // Score change lookup table
         int scoreChange = 10;
-        if (diff >= 798) scoreChange = 20;
-        else if (diff >= 511) scoreChange = 19;
-        else if (diff >= 381) scoreChange = 18;
-        else if (diff >= 301) scoreChange = 17;
-        else if (diff >= 240) scoreChange = 16;
-        else if (diff >= 190) scoreChange = 15;
-        else if (diff >= 147) scoreChange = 14;
-        else if (diff >= 107) scoreChange = 13;
-        else if (diff >= 70) scoreChange = 12;
-        else if (diff >= 34) scoreChange = 11;
+        if (diff >= 635) scoreChange = 20;
+        else if (diff >= 436) scoreChange = 19;
+        else if (diff >= 337) scoreChange = 18;
+        else if (diff >= 269) scoreChange = 17;
+        else if (diff >= 214) scoreChange = 16;
+        else if (diff >= 168) scoreChange = 15;
+        else if (diff >= 126) scoreChange = 14;
+        else if (diff >= 88) scoreChange = 13;
+        else if (diff >= 52) scoreChange = 12;
+        else if (diff >= 17) scoreChange = 11;
         // Depending on result (win/draw/lose), calculate score changes
         if (resultA == 2) {
             return ((reverse ? 20-scoreChange : scoreChange ),

--- a/contract/ELO.sol
+++ b/contract/ELO.sol
@@ -50,16 +50,16 @@ library ELO {
         uint diff = abs(difference); // take absolute to lookup in positive table
         // Score change lookup table
         int scoreChange = 10;
-        if (diff >= 635) scoreChange = 20;
-        else if (diff >= 436) scoreChange = 19;
-        else if (diff >= 337) scoreChange = 18;
-        else if (diff >= 269) scoreChange = 17;
-        else if (diff >= 214) scoreChange = 16;
-        else if (diff >= 168) scoreChange = 15;
-        else if (diff >= 126) scoreChange = 14;
-        else if (diff >= 88) scoreChange = 13;
-        else if (diff >= 52) scoreChange = 12;
-        else if (diff >= 17) scoreChange = 11;
+        if (diff > 636) scoreChange = 20;
+        else if (diff > 436) scoreChange = 19;
+        else if (diff > 338) scoreChange = 18;
+        else if (diff > 269) scoreChange = 17;
+        else if (diff > 214) scoreChange = 16;
+        else if (diff > 168) scoreChange = 15;
+        else if (diff > 126) scoreChange = 14;
+        else if (diff > 88) scoreChange = 13;
+        else if (diff > 52) scoreChange = 12;
+        else if (diff > 17) scoreChange = 11;
         // Depending on result (win/draw/lose), calculate score changes
         if (resultA == 2) {
             return ((reverse ? 20-scoreChange : scoreChange ),

--- a/contract/EloTest.sol
+++ b/contract/EloTest.sol
@@ -1,0 +1,20 @@
+/**
+ * Contract to test ELO implementation
+ */
+
+import "ELO.sol";
+
+contract EloTest {
+    using ELO for ELO.Scores;
+    ELO.Scores eloScores;
+
+    event EloScoreUpdate(address player, uint score);
+
+    function EloTest() { }
+
+    function recordResult(address player1, address player2, address winner) {
+        eloScores.recordResult(player1, player2, winner);
+        EloScoreUpdate(player1, eloScores.getScore(player1));
+        EloScoreUpdate(player2, eloScores.getScore(player2));
+    }
+}

--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
     "webpack": "^1.13.0",
     "webpack-dev-server": "^1.14.1",
     "webpack-node-externals": "*"
+  },
+  "dependencies": {
+    "async": "^1.5.2"
   }
 }

--- a/test/test_contract.js
+++ b/test/test_contract.js
@@ -1,6 +1,7 @@
 /* global describe, it, beforeEach */
 import { Chess, web3 } from '../contract/Chess.sol';
 import { gameStateDisplay } from './utils';
+import { Plan } from './utils.js';
 
 var assert = require('chai').assert;
 
@@ -485,18 +486,41 @@ describe('Chess contract', function() {
     });
 
     describe('confirmGameEnded()', () => {
-      it('should allow confirmGameEnded after claimWin', (done) => {
+      it('should allow confirmGameEnded after claimWin, update state and ELO scores', (done) => {
         assert.doesNotThrow(() => {
           Chess.claimWin(gameId, {from: player2, gas: 200000});
           Chess.confirmGameEnded(gameId, {from: player1, gas: 200000});
         });
 
+        let plan = new Plan(3, () => {
+          done();
+        });
+
+        // GameEnded event
         let filter = Chess.GameEnded({});
         filter.watch((error, result) => {
           assert.equal(gameId, result.args.gameId);
           assert.equal(player2, result.args.winner);
           filter.stopWatching();
-          done();
+          plan.ok();
+        });
+
+        // EloScoreUpdate event P2
+        let filter2 = Chess.EloScoreUpdate({player: player2});
+        filter2.watch((error, result) => {
+          assert.equal(player2, result.args.player);
+          assert.equal(110, result.args.score.toNumber());
+          filter2.stopWatching();
+          plan.ok();
+        });
+
+        // EloScoreUpdate event P1
+        let filter3 = Chess.EloScoreUpdate({player: player1});
+        filter3.watch((error, result) => {
+          assert.equal(player1, result.args.player);
+          assert.equal(100, result.args.score.toNumber());
+          filter3.stopWatching();
+          plan.ok();
         });
       });
 

--- a/test/test_elo.js
+++ b/test/test_elo.js
@@ -7,7 +7,7 @@ var async = require('async');
 
 
 describe('ELO library', function() {
-  this.timeout(15000);
+  this.timeout(25000);
   this.slow(500);
   const player1 = web3.eth.accounts[0];
   const player2 = web3.eth.accounts[1];
@@ -36,10 +36,11 @@ describe('ELO library', function() {
     it('correctly record a number of games', function (done) {
       let results = [
         // winner, new score player 1, new score player 2
+        // Start: 110, 100
         [player1, 120, 100],  // +10, -10   (floored at 100)
         [player1, 130, 100],  // +10, -10
         [player1, 140, 100],  // +10, -10
-        [player1, 149, 100],  //  +9, -11
+        [player1, 149, 100],  //  +9,  -9
         [player2, 140, 111],  //  -9, +11
         [player2, 130, 121],  // -10, +10
         [player1, 140, 111],  // +10, -10
@@ -49,6 +50,10 @@ describe('ELO library', function() {
         [player1, 177, 100],  //  +9,  -9
         [player1, 185, 100],  //  +8,  -8
         [player2, 177, 112],  //  -8, +12
+        [0,       176, 113],  //  -1,  +1
+        [player2, 167, 124],  //  -9, +11
+        [player2, 158, 135],  //  -9, +11
+        [0,       158, 135],  //  -0,  +0
       ];
 
       // Test a couple of results after each other
@@ -62,12 +67,12 @@ describe('ELO library', function() {
         });
         filter.watch(function(error, result){
           if (result.args.player === player1) {
-            let resultText = (winner === player1 ? 'winning' : 'losing');
+            let resultText = (winner === player1 ? 'winning' : (!winner?'draw':'losing'));
             let msg = 'After ' + resultText + ', player 1 score should be ' + score1;
             assert.equal(score1, result.args.score.toNumber(), msg);
           }
           if (result.args.player === player2) {
-            let resultText = (winner === player2 ? 'winning' : 'losing');
+            let resultText = (winner === player2 ? 'winning' : (!winner?'draw':'losing'));
             let msg = 'After ' + resultText + ', player 2 score should be ' + score2;
             assert.equal(score2, result.args.score.toNumber(), msg);
           }

--- a/test/test_elo.js
+++ b/test/test_elo.js
@@ -1,0 +1,79 @@
+/* global describe, it */
+import { EloTest, web3 } from '../contract/EloTest.sol';
+import { Plan } from './utils.js';
+
+var assert = require('chai').assert;
+var async = require('async');
+
+
+describe('ELO library', function() {
+  this.timeout(15000);
+  this.slow(500);
+  const player1 = web3.eth.accounts[0];
+  const player2 = web3.eth.accounts[1];
+  web3.eth.defaultAccount = player1;
+
+  describe('Recording game result', function () {
+    it('correctly initialize scores with floor and record win of P1', function (done) {
+      EloTest.recordResult(player1, player2, player1);
+
+      let filter = EloTest.EloScoreUpdate({});
+      let plan = new Plan(2, () => {
+        filter.stopWatching();
+        done();
+      });
+      filter.watch(function(error, result){
+        if (result.args.player === player1) {
+          assert.equal(110, result.args.score.toNumber());
+        }
+        if (result.args.player === player2) {
+          assert.equal(100, result.args.score.toNumber());
+        }
+        plan.ok();
+      });
+    });
+
+    it('correctly record a number of games', function (done) {
+      let results = [
+        // winner, new score player 1, new score player 2
+        [player1, 120, 100],  // +10, -10   (floored at 100)
+        [player1, 130, 100],  // +10, -10
+        [player1, 140, 100],  // +10, -10
+        [player1, 149, 100],  //  +9, -11
+        [player2, 140, 111],  //  -9, +11
+        [player2, 130, 121],  // -10, +10
+        [player1, 140, 111],  // +10, -10
+        [player1, 150, 101],  // +10, -10
+        [player1, 159, 100],  //  +9,  -9
+        [player1, 168, 100],  //  +9,  -9
+        [player1, 177, 100],  //  +9,  -9
+        [player1, 185, 100],  //  +8,  -8
+        [player2, 177, 112],  //  -8, +12
+      ];
+
+      // Test a couple of results after each other
+      async.mapSeries(results, (item, callback) => {
+        let [winner, score1, score2] = item;
+        EloTest.recordResult(player1, player2, winner);
+        let filter = EloTest.EloScoreUpdate({});
+        let plan = new Plan(2, () => {
+          filter.stopWatching();
+          callback();
+        });
+        filter.watch(function(error, result){
+          if (result.args.player === player1) {
+            let resultText = (winner === player1 ? 'winning' : 'losing');
+            let msg = 'After ' + resultText + ', player 1 score should be ' + score1;
+            assert.equal(score1, result.args.score.toNumber(), msg);
+          }
+          if (result.args.player === player2) {
+            let resultText = (winner === player2 ? 'winning' : 'losing');
+            let msg = 'After ' + resultText + ', player 2 score should be ' + score2;
+            assert.equal(score2, result.args.score.toNumber(), msg);
+          }
+          plan.ok();
+        });
+      }, done);
+    });
+  });
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -9,3 +9,23 @@ export const gameStateDisplay = (state) => {
   }
   return rows.join('\n');
 };
+
+var assert = require('chai').assert;
+
+export class Plan {
+  constructor(count, done) {
+    this.done = done;
+    this.count = count;
+  }
+
+  ok() {
+    if (this.count === 0) {
+      assert(false, 'Too many assertions called');
+    } else {
+      this.count--;
+    }
+    if (this.count === 0) {
+      this.done();
+    }
+  }
+}


### PR DESCRIPTION
Closes #22 
## Notes

Uses a lookup table for score changes.
Table is calculated based on the inverse of the Elo estimated score function: https://docs.google.com/spreadsheets/d/15xMP8xDOFswUHnqGWkj3fe-T8Ase_yFr6kpo9qTEEZ0/edit?usp=sharing

Of the 6 (12) cases (old score difference < 0 or >=0 \* result 1, 0.5 or 0, for both players), only one needs to be stored in the table because all other can be calculated from it.
